### PR TITLE
fix(deps): allow studio v5 in peer deps ranges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "@sanity/dashboard": "^4",
         "react": "^18.3 || ^19",
         "react-dom": "^18.3 || ^19",
-        "sanity": "^3 || ^4.0.0-0",
+        "sanity": "^3 || ^4.0.0-0 || ^5.0.0",
         "styled-components": "^6.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@sanity/dashboard": "^4",
     "react": "^18.3 || ^19",
     "react-dom": "^18.3 || ^19",
-    "sanity": "^3 || ^4.0.0-0",
+    "sanity": "^3 || ^4.0.0-0|| ^5.0.0",
     "styled-components": "^6.1"
   },
   "engines": {


### PR DESCRIPTION
### Description
This pull request updates the peer dependencies to support Sanity version 5.x, allowing the plugin to work with the latest major version of Sanity Studio while maintaining backward compatibility with versions 3.x and 4.x.